### PR TITLE
feat: Add dynamic display resizing for Samsung DeX

### DIFF
--- a/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
@@ -163,9 +163,13 @@ fun PAUXBApp(
         AppStreamScreen(
             appName = streamingApp!!.name,
             vncPort = streamingApp!!.vncPort ?: 5910,
+            appId = streamingApp!!.id,
             onBack = {
                 streamingApp = null
                 currentScreen = Screen.APPS
+            },
+            onResizeRequest = { appId, width, height ->
+                bridge.resizeApp(appId, width, height)
             }
         )
         return

--- a/src/app/src/main/java/ch/pianonic/pauxb/bridge/TermuxBridge.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/bridge/TermuxBridge.kt
@@ -156,6 +156,14 @@ class TermuxBridge(private val context: Context) {
     }
 
     /**
+     * Resize a running app's virtual display to match the new viewport size.
+     * Uses xrandr to change the Xvfb resolution dynamically.
+     */
+    fun resizeApp(appId: String, width: Int, height: Int) {
+        bridgeCommand("resize $appId $width $height")
+    }
+
+    /**
      * Install a package in Debian
      */
     fun installPackage(packageName: String) {

--- a/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/AppStreamScreen.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/AppStreamScreen.kt
@@ -24,7 +24,9 @@ import ch.pianonic.pauxb.vnc.VncView
 fun AppStreamScreen(
     appName: String,
     vncPort: Int,
+    appId: String = "",
     onBack: () -> Unit,
+    onResizeRequest: ((String, Int, Int) -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     val vncClient = remember { VncClient() }
@@ -43,6 +45,15 @@ fun AppStreamScreen(
         activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         onDispose {
             activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
+    // Wire up resize callback to bridge
+    LaunchedEffect(Unit) {
+        if (onResizeRequest != null && appId.isNotEmpty()) {
+            vncClient.setResizeCallback { w, h ->
+                onResizeRequest(appId, w, h)
+            }
         }
     }
 

--- a/src/app/src/main/java/ch/pianonic/pauxb/vnc/VncClient.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/vnc/VncClient.kt
@@ -327,14 +327,32 @@ class VncClient {
     fun getFrameWidth() = fbWidth
     fun getFrameHeight() = fbHeight
 
+    private var viewportWidth = 0
+    private var viewportHeight = 0
+    private var resizeCallback: ((Int, Int) -> Unit)? = null
+
+    /**
+     * Set a callback that will be invoked when the viewport size changes significantly.
+     * Used to trigger xrandr resize via the bridge daemon.
+     */
+    fun setResizeCallback(callback: (width: Int, height: Int) -> Unit) {
+        resizeCallback = callback
+    }
+
     /**
      * Called when the Android viewport size changes (e.g. DeX window resize).
-     * Stores the new viewport dimensions for potential future use
-     * (e.g. requesting the VNC server to resize via xrandr).
+     * Triggers a resize callback if dimensions changed significantly.
      */
     fun onViewportResized(widthPx: Int, heightPx: Int) {
-        Log.d(TAG, "Viewport resized to ${widthPx}x${heightPx}")
-        // Future: could send a DesktopSize pseudo-encoding request
-        // or trigger an xrandr resize via the bridge daemon
+        if (widthPx <= 0 || heightPx <= 0) return
+        // Only trigger resize if changed by more than 50px (avoid noise)
+        val widthDiff = kotlin.math.abs(widthPx - viewportWidth)
+        val heightDiff = kotlin.math.abs(heightPx - viewportHeight)
+        if (widthDiff > 50 || heightDiff > 50) {
+            viewportWidth = widthPx
+            viewportHeight = heightPx
+            Log.d(TAG, "Viewport resized to ${widthPx}x${heightPx}")
+            resizeCallback?.invoke(widthPx, heightPx)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- VncClient tracks viewport size changes with 50px debounce threshold
- Window resize events trigger xrandr via the bridge daemon to resize Xvfb
- Fullscreen mode with responsive scaling for DeX desktop mode

Closes #1

## Test plan
- [x] Build succeeds
- [ ] Test on Samsung DeX with window resizing
- [x] VNC stream renders correctly in fullscreen