### PR TITLE
feat: Add settings tab with preferences

### DIFF
--- a/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
@@ -6,7 +6,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
-import android.provider.Settings
+import android.provider.Settings as SystemSettings
 import android.net.Uri
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -24,6 +25,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 import ch.pianonic.pauxb.bridge.TermuxBridge
 import ch.pianonic.pauxb.data.AppStorage
+import ch.pianonic.pauxb.data.SettingsStorage
 import ch.pianonic.pauxb.terminal.TerminalSession
 import ch.pianonic.pauxb.ui.screens.*
 import ch.pianonic.pauxb.ui.theme.PAUXBTheme
@@ -33,6 +35,7 @@ import kotlinx.coroutines.launch
 class MainActivity : ComponentActivity() {
     private lateinit var bridge: TermuxBridge
     private lateinit var appStorage: AppStorage
+    private lateinit var settingsStorage: SettingsStorage
     private val terminalSession = TerminalSession()
 
     private var launchAppId: String? = null
@@ -43,16 +46,24 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         bridge = TermuxBridge(this)
         appStorage = AppStorage(this)
+        settingsStorage = SettingsStorage(this)
         enableEdgeToEdge()
 
         handleLaunchIntent(intent)
         requestStoragePermission()
 
         setContent {
-            PAUXBTheme {
+            val themeMode by settingsStorage.themeMode.collectAsState()
+            val dynamicColor by settingsStorage.dynamicColor.collectAsState()
+
+            PAUXBTheme(
+                themeMode = themeMode,
+                dynamicColor = dynamicColor
+            ) {
                 PAUXBApp(
                     bridge = bridge,
                     appStorage = appStorage,
+                    settingsStorage = settingsStorage,
                     terminalSession = terminalSession,
                     launchAppId = launchAppId,
                     launchAppName = launchAppName,
@@ -65,7 +76,7 @@ class MainActivity : ComponentActivity() {
     private fun requestStoragePermission() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             if (!Environment.isExternalStorageManager()) {
-                val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
+                val intent = Intent(SystemSettings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION).apply {
                     data = Uri.parse("package:$packageName")
                 }
                 startActivity(intent)
@@ -99,13 +110,14 @@ class MainActivity : ComponentActivity() {
 }
 
 enum class Screen {
-    SETUP, APPS, TERMINAL, APP_STREAM
+    SETUP, APPS, TERMINAL, SETTINGS, APP_STREAM
 }
 
 @Composable
 fun PAUXBApp(
     bridge: TermuxBridge,
     appStorage: AppStorage,
+    settingsStorage: SettingsStorage,
     terminalSession: TerminalSession,
     launchAppId: String? = null,
     launchAppName: String? = null,
@@ -195,6 +207,12 @@ fun PAUXBApp(
                     label = { Text("Terminal") },
                     selected = currentScreen == Screen.TERMINAL,
                     onClick = { currentScreen = Screen.TERMINAL }
+                )
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.Settings, contentDescription = "Settings") },
+                    label = { Text("Settings") },
+                    selected = currentScreen == Screen.SETTINGS,
+                    onClick = { currentScreen = Screen.SETTINGS }
                 )
             }
         }
@@ -290,6 +308,11 @@ fun PAUXBApp(
 
             Screen.TERMINAL -> TerminalScreen(
                 session = terminalSession,
+                modifier = Modifier.padding(innerPadding)
+            )
+
+            Screen.SETTINGS -> SettingsScreen(
+                settingsStorage = settingsStorage,
                 modifier = Modifier.padding(innerPadding)
             )
 

--- a/src/app/src/main/java/ch/pianonic/pauxb/data/SettingsStorage.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/data/SettingsStorage.kt
@@ -1,0 +1,64 @@
+package ch.pianonic.pauxb.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+enum class ThemeMode { SYSTEM, LIGHT, DARK }
+
+class SettingsStorage(context: Context) {
+
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("pauxb_settings", Context.MODE_PRIVATE)
+
+    private val _themeMode = MutableStateFlow(loadThemeMode())
+    val themeMode: StateFlow<ThemeMode> = _themeMode
+
+    private val _dynamicColor = MutableStateFlow(loadDynamicColor())
+    val dynamicColor: StateFlow<Boolean> = _dynamicColor
+
+    private val _defaultVncPort = MutableStateFlow(loadDefaultVncPort())
+    val defaultVncPort: StateFlow<Int> = _defaultVncPort
+
+    private val _defaultResolution = MutableStateFlow(loadDefaultResolution())
+    val defaultResolution: StateFlow<String> = _defaultResolution
+
+    private val _keepScreenOn = MutableStateFlow(loadKeepScreenOn())
+    val keepScreenOn: StateFlow<Boolean> = _keepScreenOn
+
+    fun setThemeMode(mode: ThemeMode) {
+        prefs.edit().putString("theme_mode", mode.name).apply()
+        _themeMode.value = mode
+    }
+
+    fun setDynamicColor(enabled: Boolean) {
+        prefs.edit().putBoolean("dynamic_color", enabled).apply()
+        _dynamicColor.value = enabled
+    }
+
+    fun setDefaultVncPort(port: Int) {
+        prefs.edit().putInt("default_vnc_port", port).apply()
+        _defaultVncPort.value = port
+    }
+
+    fun setDefaultResolution(resolution: String) {
+        prefs.edit().putString("default_resolution", resolution).apply()
+        _defaultResolution.value = resolution
+    }
+
+    fun setKeepScreenOn(enabled: Boolean) {
+        prefs.edit().putBoolean("keep_screen_on", enabled).apply()
+        _keepScreenOn.value = enabled
+    }
+
+    private fun loadThemeMode(): ThemeMode {
+        val name = prefs.getString("theme_mode", ThemeMode.SYSTEM.name)
+        return try { ThemeMode.valueOf(name!!) } catch (_: Exception) { ThemeMode.SYSTEM }
+    }
+
+    private fun loadDynamicColor(): Boolean = prefs.getBoolean("dynamic_color", true)
+    private fun loadDefaultVncPort(): Int = prefs.getInt("default_vnc_port", 5910)
+    private fun loadDefaultResolution(): String = prefs.getString("default_resolution", "1280x720") ?: "1280x720"
+    private fun loadKeepScreenOn(): Boolean = prefs.getBoolean("keep_screen_on", true)
+}

--- a/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/SettingsScreen.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/SettingsScreen.kt
@@ -1,0 +1,197 @@
+package ch.pianonic.pauxb.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ch.pianonic.pauxb.data.SettingsStorage
+import ch.pianonic.pauxb.data.ThemeMode
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    settingsStorage: SettingsStorage,
+    modifier: Modifier = Modifier
+) {
+    val themeMode by settingsStorage.themeMode.collectAsState()
+    val dynamicColor by settingsStorage.dynamicColor.collectAsState()
+    val defaultVncPort by settingsStorage.defaultVncPort.collectAsState()
+    val defaultResolution by settingsStorage.defaultResolution.collectAsState()
+    val keepScreenOn by settingsStorage.keepScreenOn.collectAsState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "Settings",
+            style = MaterialTheme.typography.headlineMedium,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+
+        // Appearance section
+        Text(
+            text = "Appearance",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        // Theme mode
+        var themeExpanded by remember { mutableStateOf(false) }
+        ExposedDropdownMenuBox(
+            expanded = themeExpanded,
+            onExpandedChange = { themeExpanded = it }
+        ) {
+            OutlinedTextField(
+                value = when (themeMode) {
+                    ThemeMode.SYSTEM -> "System default"
+                    ThemeMode.LIGHT -> "Light"
+                    ThemeMode.DARK -> "Dark"
+                },
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Theme") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = themeExpanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor()
+            )
+            ExposedDropdownMenu(
+                expanded = themeExpanded,
+                onDismissRequest = { themeExpanded = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text("System default") },
+                    onClick = {
+                        settingsStorage.setThemeMode(ThemeMode.SYSTEM)
+                        themeExpanded = false
+                    }
+                )
+                DropdownMenuItem(
+                    text = { Text("Light") },
+                    onClick = {
+                        settingsStorage.setThemeMode(ThemeMode.LIGHT)
+                        themeExpanded = false
+                    }
+                )
+                DropdownMenuItem(
+                    text = { Text("Dark") },
+                    onClick = {
+                        settingsStorage.setThemeMode(ThemeMode.DARK)
+                        themeExpanded = false
+                    }
+                )
+            }
+        }
+
+        // Dynamic color
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Dynamic color", style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    "Use wallpaper-based colors (Android 12+)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = dynamicColor,
+                onCheckedChange = { settingsStorage.setDynamicColor(it) }
+            )
+        }
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+        // Streaming section
+        Text(
+            text = "Streaming",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        // Default VNC port
+        var portText by remember(defaultVncPort) { mutableStateOf(defaultVncPort.toString()) }
+        OutlinedTextField(
+            value = portText,
+            onValueChange = { newValue ->
+                portText = newValue
+                newValue.toIntOrNull()?.let { port ->
+                    if (port in 1024..65535) {
+                        settingsStorage.setDefaultVncPort(port)
+                    }
+                }
+            },
+            label = { Text("Default VNC port") },
+            supportingText = { Text("Port range: 1024-65535") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        // Default resolution
+        var resolutionExpanded by remember { mutableStateOf(false) }
+        val resolutions = listOf("1280x720", "1920x1080", "2560x1440", "1024x768", "1600x900")
+        ExposedDropdownMenuBox(
+            expanded = resolutionExpanded,
+            onExpandedChange = { resolutionExpanded = it }
+        ) {
+            OutlinedTextField(
+                value = defaultResolution,
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("Default resolution") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = resolutionExpanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor()
+            )
+            ExposedDropdownMenu(
+                expanded = resolutionExpanded,
+                onDismissRequest = { resolutionExpanded = false }
+            ) {
+                resolutions.forEach { res ->
+                    DropdownMenuItem(
+                        text = { Text(res) },
+                        onClick = {
+                            settingsStorage.setDefaultResolution(res)
+                            resolutionExpanded = false
+                        }
+                    )
+                }
+            }
+        }
+
+        // Keep screen on
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Keep screen on", style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    "Prevent display from sleeping while streaming",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = keepScreenOn,
+                onCheckedChange = { settingsStorage.setKeepScreenOn(it) }
+            )
+        }
+    }
+}

--- a/src/app/src/main/java/ch/pianonic/pauxb/ui/theme/Theme.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package ch.pianonic.pauxb.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -10,6 +9,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import ch.pianonic.pauxb.data.ThemeMode
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,
@@ -35,11 +35,16 @@ private val LightColorScheme = lightColorScheme(
 
 @Composable
 fun PAUXBTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
+    themeMode: ThemeMode = ThemeMode.SYSTEM,
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
+    val darkTheme = when (themeMode) {
+        ThemeMode.SYSTEM -> isSystemInDarkTheme()
+        ThemeMode.LIGHT -> false
+        ThemeMode.DARK -> true
+    }
+
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current


### PR DESCRIPTION
## Summary
- Add Settings screen with theme mode (System/Light/Dark), dynamic color toggle, default VNC port, resolution, and keep screen on settings
- Persist all settings via SharedPreferences with reactive StateFlow updates
- Wire theme settings into PAUXBTheme for live theme switching

Closes #10

## Test plan
- [x] Settings tab appears in bottom navigation
- [x] Theme dropdown works (System/Light/Dark)
- [x] Dynamic color toggle works
- [x] VNC port and resolution fields are functional
- [x] Keep screen on toggle works
- [x] Settings persist across app restarts