### PR TITLE
fix: Detect and request RUN_COMMAND permission before setup

### DIFF
--- a/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
@@ -42,6 +42,14 @@ class MainActivity : ComponentActivity() {
     private var launchAppName: String? = null
     private var launchAppCommand: String? = null
 
+    private var hasRunCommandPermission = mutableStateOf(false)
+
+    private val runCommandPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        hasRunCommandPermission.value = granted
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         bridge = TermuxBridge(this)
@@ -52,9 +60,12 @@ class MainActivity : ComponentActivity() {
         handleLaunchIntent(intent)
         requestStoragePermission()
 
+        hasRunCommandPermission.value = bridge.hasRunCommandPermission()
+
         setContent {
             val themeMode by settingsStorage.themeMode.collectAsState()
             val dynamicColor by settingsStorage.dynamicColor.collectAsState()
+            val permissionGranted by hasRunCommandPermission
 
             PAUXBTheme(
                 themeMode = themeMode,
@@ -67,7 +78,11 @@ class MainActivity : ComponentActivity() {
                     terminalSession = terminalSession,
                     launchAppId = launchAppId,
                     launchAppName = launchAppName,
-                    launchAppCommand = launchAppCommand
+                    launchAppCommand = launchAppCommand,
+                    hasRunCommandPermission = permissionGranted,
+                    onRequestRunCommandPermission = {
+                        runCommandPermissionLauncher.launch("com.termux.permission.RUN_COMMAND")
+                    }
                 )
             }
         }
@@ -88,6 +103,11 @@ class MainActivity : ComponentActivity() {
                     .launch(Manifest.permission.READ_EXTERNAL_STORAGE)
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        hasRunCommandPermission.value = bridge.hasRunCommandPermission()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -121,7 +141,9 @@ fun PAUXBApp(
     terminalSession: TerminalSession,
     launchAppId: String? = null,
     launchAppName: String? = null,
-    launchAppCommand: String? = null
+    launchAppCommand: String? = null,
+    hasRunCommandPermission: Boolean = true,
+    onRequestRunCommandPermission: () -> Unit = {}
 ) {
     var currentScreen by remember { mutableStateOf(Screen.SETUP) }
     var setupStatus by remember { mutableStateOf("Not started") }
@@ -247,6 +269,8 @@ fun PAUXBApp(
                     onOpenTermux = { bridge.openTermux() },
                     setupStatus = setupStatus,
                     isSettingUp = isSettingUp,
+                    hasRunCommandPermission = hasRunCommandPermission,
+                    onRequestPermission = onRequestRunCommandPermission,
                     modifier = Modifier.padding(innerPadding)
                 )
             }

--- a/src/app/src/main/java/ch/pianonic/pauxb/bridge/TermuxBridge.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/bridge/TermuxBridge.kt
@@ -2,10 +2,12 @@ package ch.pianonic.pauxb.bridge
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
 import android.graphics.drawable.Icon
 import android.util.Log
+import androidx.core.content.ContextCompat
 import kotlinx.coroutines.*
 import java.io.*
 
@@ -43,6 +45,17 @@ class TermuxBridge(private val context: Context) {
         } catch (e: Exception) {
             false
         }
+    }
+
+    /**
+     * Check if the RUN_COMMAND permission is granted.
+     * This permission is required to execute commands in Termux.
+     */
+    fun hasRunCommandPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context,
+            "com.termux.permission.RUN_COMMAND"
+        ) == PackageManager.PERMISSION_GRANTED
     }
 
     /**

--- a/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/SetupScreen.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/SetupScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -20,6 +21,8 @@ fun SetupScreen(
     onOpenTermux: () -> Unit,
     setupStatus: String,
     isSettingUp: Boolean,
+    hasRunCommandPermission: Boolean = true,
+    onRequestPermission: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     // Parse current phase from status string
@@ -118,11 +121,55 @@ fun SetupScreen(
             }
         }
 
+        if (!hasRunCommandPermission) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Warning,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error
+                        )
+                        Text(
+                            text = "Permission Required",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                    Text(
+                        text = "PAUXB needs permission to run commands in Termux. Tap below to grant it.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                    Button(
+                        onClick = onRequestPermission,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Grant Permission")
+                    }
+                }
+            }
+        }
+
         Spacer(modifier = Modifier.height(8.dp))
 
         Button(
             onClick = onRunSetup,
-            enabled = !isSettingUp,
+            enabled = !isSettingUp && hasRunCommandPermission,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp)


### PR DESCRIPTION
## Summary
- Add `hasRunCommandPermission()` check in `TermuxBridge`
- Request `com.termux.permission.RUN_COMMAND` at runtime via `ActivityResultContracts`
- Show a warning card on the Setup screen when permission is missing
- Disable "Run Setup" button until permission is granted

## Test plan
- [ ] Fresh install: verify permission warning appears on Setup screen
- [ ] Tap "Grant Permission" and approve: warning disappears, Run Setup enables
- [ ] Deny permission: warning remains, Run Setup stays disabled

Closes #12