### PR TITLE
fix: Detect and guide users when Termux allow-external-apps is disabled

### DIFF
--- a/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
@@ -148,6 +148,7 @@ fun PAUXBApp(
     var currentScreen by remember { mutableStateOf(Screen.SETUP) }
     var setupStatus by remember { mutableStateOf("Not started") }
     var isSettingUp by remember { mutableStateOf(false) }
+    var isTermuxReady by remember { mutableStateOf(true) }
     var apps by remember { mutableStateOf(appStorage.loadApps()) }
     var discoveredApps by remember { mutableStateOf(listOf<TermuxBridge.DiscoveredApp>()) }
     var streamingApp by remember { mutableStateOf<LinuxApp?>(null) }
@@ -161,10 +162,26 @@ fun PAUXBApp(
     // Check if Termux is installed and scan for apps on launch
     LaunchedEffect(Unit) {
         if (bridge.isTermuxInstalled()) {
-            setupStatus = "Termux is installed. Ready to setup."
+            isTermuxReady = bridge.isTermuxExternalAppsEnabled()
+            if (isTermuxReady) {
+                setupStatus = "Termux is installed. Ready to setup."
+            } else {
+                setupStatus = "Termux needs configuration. See instructions below."
+            }
             discoveredApps = bridge.getInstalledApps()
         } else {
             setupStatus = "Termux not found. Please install Termux from GitHub."
+            isTermuxReady = false
+        }
+    }
+
+    // Re-check Termux readiness when permission changes
+    LaunchedEffect(hasRunCommandPermission) {
+        if (hasRunCommandPermission && bridge.isTermuxInstalled()) {
+            isTermuxReady = bridge.isTermuxExternalAppsEnabled()
+            if (isTermuxReady) {
+                setupStatus = "Termux is installed. Ready to setup."
+            }
         }
     }
 
@@ -271,6 +288,7 @@ fun PAUXBApp(
                     isSettingUp = isSettingUp,
                     hasRunCommandPermission = hasRunCommandPermission,
                     onRequestPermission = onRequestRunCommandPermission,
+                    isTermuxReady = isTermuxReady,
                     modifier = Modifier.padding(innerPadding)
                 )
             }

--- a/src/app/src/main/java/ch/pianonic/pauxb/bridge/TermuxBridge.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/bridge/TermuxBridge.kt
@@ -83,9 +83,30 @@ class TermuxBridge(private val context: Context) {
     }
 
     /**
-     * Execute a command in Termux via the RUN_COMMAND intent
+     * Check if Termux has allow-external-apps enabled by attempting
+     * to resolve the RunCommandService. If the service can't be reached,
+     * it likely means allow-external-apps is not set to true.
      */
-    fun runInTermux(command: String, background: Boolean = false) {
+    fun isTermuxExternalAppsEnabled(): Boolean {
+        if (!isTermuxInstalled()) return false
+        return try {
+            val intent = Intent(ACTION_RUN_COMMAND).apply {
+                setClassName(TERMUX_PKG, TERMUX_SERVICE)
+            }
+            val resolveInfo = context.packageManager.resolveService(intent, 0)
+            resolveInfo != null
+        } catch (e: Exception) {
+            Log.w(TAG, "Could not check Termux external apps status", e)
+            false
+        }
+    }
+
+    /**
+     * Execute a command in Termux via the RUN_COMMAND intent.
+     * Returns true if the intent was sent successfully, false if it failed
+     * (e.g. allow-external-apps not enabled).
+     */
+    fun runInTermux(command: String, background: Boolean = false): Boolean {
         val intent = Intent(ACTION_RUN_COMMAND).apply {
             setClassName(TERMUX_PKG, TERMUX_SERVICE)
             putExtra("com.termux.RUN_COMMAND_PATH", "/data/data/com.termux/files/usr/bin/bash")
@@ -94,14 +115,17 @@ class TermuxBridge(private val context: Context) {
             putExtra("com.termux.RUN_COMMAND_BACKGROUND", background)
         }
 
-        try {
+        return try {
             context.startForegroundService(intent)
+            true
         } catch (e: Exception) {
-            // Fallback to startService
             try {
                 context.startService(intent)
+                true
             } catch (e2: Exception) {
-                Log.e(TAG, "Failed to run command in Termux", e2)
+                Log.e(TAG, "Failed to run command in Termux. " +
+                    "Ensure allow-external-apps is enabled in Termux.", e2)
+                false
             }
         }
     }

--- a/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/SetupScreen.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/SetupScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -23,6 +24,7 @@ fun SetupScreen(
     isSettingUp: Boolean,
     hasRunCommandPermission: Boolean = true,
     onRequestPermission: () -> Unit = {},
+    isTermuxReady: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     // Parse current phase from status string
@@ -165,11 +167,63 @@ fun SetupScreen(
             }
         }
 
+        if (hasRunCommandPermission && !isTermuxReady) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.tertiaryContainer
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Info,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.tertiary
+                        )
+                        Text(
+                            text = "Termux Configuration Needed",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.tertiary
+                        )
+                    }
+                    Text(
+                        text = "Termux needs to allow external apps. Open Termux and run:",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer
+                    )
+                    Text(
+                        text = "echo 'allow-external-apps = true' >> ~/.termux/termux.properties",
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer
+                    )
+                    Text(
+                        text = "Then restart Termux and return here.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer
+                    )
+                    OutlinedButton(
+                        onClick = onOpenTermux,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("Open Termux")
+                    }
+                }
+            }
+        }
+
         Spacer(modifier = Modifier.height(8.dp))
 
         Button(
             onClick = onRunSetup,
-            enabled = !isSettingUp && hasRunCommandPermission,
+            enabled = !isSettingUp && hasRunCommandPermission && isTermuxReady,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(56.dp)


### PR DESCRIPTION
## Summary
- Add `isTermuxExternalAppsEnabled()` check in `TermuxBridge` that verifies Termux's RunCommandService is reachable
- Show an info card on the Setup screen with the exact command to enable `allow-external-apps`
- Include "Open Termux" button for quick access
- Disable "Run Setup" button until Termux is properly configured
- `runInTermux()` now returns `Boolean` to indicate success/failure

## Test plan
- [ ] Fresh Termux install without `allow-external-apps`: info card appears with instructions
- [ ] After running the command and restarting Termux: card disappears, Run Setup enables
- [ ] Existing setup with `allow-external-apps` already enabled: no warning shown

Closes #13