### PR TITLE
Fix setup screen state persistence and text

### DIFF
--- a/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
@@ -163,7 +163,14 @@ fun PAUXBApp(
     LaunchedEffect(Unit) {
         if (bridge.isTermuxInstalled()) {
             isTermuxReady = bridge.isTermuxExternalAppsEnabled()
-            if (isTermuxReady) {
+            // Check if setup was already completed
+            bridge.pollSetupStatus()
+            delay(1500)
+            val existingStatus = bridge.getSetupStatus()
+            if (existingStatus.contains("SETUP_COMPLETE") || existingStatus.contains("PHASE:COMPLETE")) {
+                setupStatus = existingStatus
+                isSettingUp = false
+            } else if (isTermuxReady) {
                 setupStatus = "Termux is installed. Ready to setup."
             } else {
                 setupStatus = "Termux needs configuration. See instructions below."

--- a/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/SetupScreen.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/SetupScreen.kt
@@ -41,10 +41,10 @@ fun SetupScreen(
     val isComplete = currentPhase >= 5
 
     // Extract the human-readable message after the phase prefix
-    val statusMessage = if (setupStatus.contains(" - ")) {
-        setupStatus.substringAfter(" - ")
-    } else {
-        setupStatus
+    val statusMessage = when {
+        setupStatus.contains("SETUP_COMPLETE") -> "Setup complete!"
+        setupStatus.contains(" - ") -> setupStatus.substringAfter(" - ")
+        else -> setupStatus
     }
 
     Column(
@@ -116,7 +116,7 @@ fun SetupScreen(
                     text = "What this will set up:",
                     style = MaterialTheme.typography.titleSmall
                 )
-                SetupStep("1", "Install proot-distro & VNC in Termux", completed = currentPhase > 1)
+                SetupStep("1", "Install Termux dependencies", completed = currentPhase > 1)
                 SetupStep("2", "Install Debian Linux environment", completed = currentPhase > 2)
                 SetupStep("3", "Configure X11/VNC display streaming", completed = currentPhase > 3)
                 SetupStep("4", "Install PAUXB bridge daemon", completed = currentPhase > 4)


### PR DESCRIPTION
## Summary
- Show "Setup complete!" instead of raw `SETUP_COMPLETE` in status
- Updated step 1 text from "Install proot-distro & VNC in Termux" to "Install Termux dependencies" (tigervnc was removed in PR #23)
- Check existing setup status file on app launch — completed state now persists across tab switches and app restarts

## Test plan
- [ ] Complete setup, switch tabs — state persists
- [ ] Kill and reopen app after setup — shows completed state
- [ ] Fresh install — shows "Not started" initially

Closes #24, closes #25