### PR TITLE
feat: Add app store with catalog and Debian search

### DIFF
--- a/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -29,6 +30,8 @@ import ch.pianonic.pauxb.terminal.TerminalSession
 import ch.pianonic.pauxb.ui.screens.LinuxApp
 import ch.pianonic.pauxb.ui.screens.SetupScreen
 import ch.pianonic.pauxb.ui.screens.AppsScreen
+import ch.pianonic.pauxb.ui.screens.StoreScreen
+import ch.pianonic.pauxb.ui.screens.DebianSearchResult
 import ch.pianonic.pauxb.ui.screens.TerminalScreen
 import ch.pianonic.pauxb.ui.screens.SettingsScreen
 import ch.pianonic.pauxb.ui.theme.PAUXBTheme
@@ -112,7 +115,7 @@ class MainActivity : ComponentActivity() {
 }
 
 enum class Screen {
-    SETUP, APPS, TERMINAL, SETTINGS
+    SETUP, APPS, STORE, TERMINAL, SETTINGS
 }
 
 @Composable
@@ -130,6 +133,8 @@ fun PAUXBApp(
     var isTermuxReady by remember { mutableStateOf(true) }
     var apps by remember { mutableStateOf(appStorage.loadApps()) }
     var discoveredApps by remember { mutableStateOf(listOf<TermuxBridge.DiscoveredApp>()) }
+    var debianSearchResults by remember { mutableStateOf(listOf<DebianSearchResult>()) }
+    var isSearchingDebian by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
     // Save apps whenever the list changes
@@ -185,6 +190,12 @@ fun PAUXBApp(
                     label = { Text("Apps") },
                     selected = currentScreen == Screen.APPS,
                     onClick = { currentScreen = Screen.APPS }
+                )
+                NavigationBarItem(
+                    icon = { Icon(Icons.Default.ShoppingCart, contentDescription = "Store") },
+                    label = { Text("Store") },
+                    selected = currentScreen == Screen.STORE,
+                    onClick = { currentScreen = Screen.STORE }
                 )
                 NavigationBarItem(
                     icon = { Icon(Icons.Default.PlayArrow, contentDescription = "Terminal") },
@@ -311,6 +322,65 @@ fun PAUXBApp(
                         )
                     }
                 },
+                modifier = Modifier.padding(innerPadding)
+            )
+
+            Screen.STORE -> StoreScreen(
+                installedAppIds = apps.map { it.id }.toSet(),
+                installingAppIds = apps.filter { it.isInstalling }.map { it.id }.toSet(),
+                onInstallApp = { name, pkg, cmd ->
+                    val appId = name.lowercase().replace(" ", "_")
+                    if (apps.none { it.id == appId }) {
+                        bridge.installPackage(pkg)
+                        apps = apps + LinuxApp(
+                            id = appId,
+                            name = name,
+                            command = cmd,
+                            packageName = pkg,
+                            isInstalling = true
+                        )
+                        scope.launch {
+                            while (true) {
+                                delay(2000)
+                                val status = bridge.getInstallStatus(pkg)
+                                if (status == "INSTALL_COMPLETE") {
+                                    apps = apps.map {
+                                        if (it.id == appId) it.copy(isInstalling = false, installError = null)
+                                        else it
+                                    }
+                                    break
+                                } else if (status == "INSTALL_FAILED") {
+                                    apps = apps.map {
+                                        if (it.id == appId) it.copy(isInstalling = false, installError = "apt-get failed")
+                                        else it
+                                    }
+                                    break
+                                }
+                            }
+                        }
+                    }
+                },
+                onSearchDebian = { query ->
+                    isSearchingDebian = true
+                    debianSearchResults = emptyList()
+                    bridge.searchDebianPackages(query)
+                    scope.launch {
+                        while (true) {
+                            delay(2000)
+                            val status = bridge.getSearchStatus()
+                            if (status == "SEARCH_DONE") {
+                                val results = bridge.getSearchResults()
+                                debianSearchResults = results.map { (name, pkg, desc) ->
+                                    DebianSearchResult(name, pkg, desc)
+                                }
+                                isSearchingDebian = false
+                                break
+                            }
+                        }
+                    }
+                },
+                debianSearchResults = debianSearchResults,
+                isSearching = isSearchingDebian,
                 modifier = Modifier.padding(innerPadding)
             )
 

--- a/src/app/src/main/java/ch/pianonic/pauxb/bridge/TermuxBridge.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/bridge/TermuxBridge.kt
@@ -229,6 +229,53 @@ class TermuxBridge(private val context: Context) {
     }
 
     /**
+     * Search Debian packages via apt-cache search.
+     * Writes results to a shared file for polling.
+     */
+    fun searchDebianPackages(query: String) {
+        runInTermux(
+            "mkdir -p /sdcard/.pauxb && " +
+            "echo 'SEARCHING' > /sdcard/.pauxb/search_status.txt && " +
+            "proot-distro login debian -- apt-cache search '$query' 2>/dev/null | head -50 > /sdcard/.pauxb/search_results.txt && " +
+            "echo 'SEARCH_DONE' > /sdcard/.pauxb/search_status.txt",
+            background = true
+        )
+    }
+
+    /**
+     * Get the Debian package search status.
+     */
+    suspend fun getSearchStatus(): String = withContext(Dispatchers.IO) {
+        try {
+            val file = File("/sdcard/.pauxb/search_status.txt")
+            if (file.exists()) file.readText().trim() else "IDLE"
+        } catch (e: Exception) {
+            "IDLE"
+        }
+    }
+
+    /**
+     * Read Debian package search results.
+     */
+    suspend fun getSearchResults(): List<Triple<String, String, String>> = withContext(Dispatchers.IO) {
+        try {
+            val file = File("/sdcard/.pauxb/search_results.txt")
+            if (!file.exists()) return@withContext emptyList()
+            file.readLines()
+                .filter { it.contains(" - ") }
+                .map { line ->
+                    val pkg = line.substringBefore(" - ").trim()
+                    val desc = line.substringAfter(" - ").trim()
+                    // Use package name as display name, capitalize first letter
+                    val displayName = pkg.replaceFirstChar { it.uppercase() }
+                    Triple(displayName, pkg, desc)
+                }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    /**
      * Get setup status by reading the status file.
      * The setup script writes progress to $PAUXB_DIR/status.
      */

--- a/src/app/src/main/java/ch/pianonic/pauxb/data/AppCatalog.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/data/AppCatalog.kt
@@ -1,0 +1,93 @@
+package ch.pianonic.pauxb.data
+
+/**
+ * Curated catalog of popular Linux GUI applications with pre-filled metadata.
+ */
+data class CatalogApp(
+    val name: String,
+    val packageName: String,
+    val command: String,
+    val description: String,
+    val category: String
+)
+
+object AppCatalog {
+
+    val categories = listOf(
+        "Browsers",
+        "Office",
+        "Graphics",
+        "Media",
+        "Development",
+        "System",
+        "Games",
+        "Communication"
+    )
+
+    val apps = listOf(
+        // Browsers
+        CatalogApp("Firefox", "firefox-esr", "firefox-esr", "Web browser by Mozilla", "Browsers"),
+        CatalogApp("Chromium", "chromium", "chromium --no-sandbox", "Open-source Chrome browser", "Browsers"),
+        CatalogApp("Midori", "midori", "midori", "Lightweight web browser", "Browsers"),
+
+        // Office
+        CatalogApp("LibreOffice Writer", "libreoffice-writer", "libreoffice --writer", "Word processor", "Office"),
+        CatalogApp("LibreOffice Calc", "libreoffice-calc", "libreoffice --calc", "Spreadsheet editor", "Office"),
+        CatalogApp("LibreOffice Impress", "libreoffice-impress", "libreoffice --impress", "Presentation editor", "Office"),
+        CatalogApp("Evince", "evince", "evince", "PDF document viewer", "Office"),
+        CatalogApp("Mousepad", "mousepad", "mousepad", "Simple text editor", "Office"),
+
+        // Graphics
+        CatalogApp("GIMP", "gimp", "gimp", "Image editor", "Graphics"),
+        CatalogApp("Inkscape", "inkscape", "inkscape", "Vector graphics editor", "Graphics"),
+        CatalogApp("Krita", "krita", "krita", "Digital painting app", "Graphics"),
+        CatalogApp("Shotwell", "shotwell", "shotwell", "Photo manager", "Graphics"),
+        CatalogApp("Eye of GNOME", "eog", "eog", "Image viewer", "Graphics"),
+
+        // Media
+        CatalogApp("VLC", "vlc", "vlc --no-xlib", "Media player", "Media"),
+        CatalogApp("Audacity", "audacity", "audacity", "Audio editor", "Media"),
+        CatalogApp("Rhythmbox", "rhythmbox", "rhythmbox", "Music player", "Media"),
+
+        // Development
+        CatalogApp("VS Code (OSS)", "codium", "codium --no-sandbox", "Code editor (open-source VS Code)", "Development"),
+        CatalogApp("Geany", "geany", "geany", "Lightweight IDE", "Development"),
+        CatalogApp("Bluefish", "bluefish", "bluefish", "Web development editor", "Development"),
+        CatalogApp("Meld", "meld", "meld", "Visual diff and merge tool", "Development"),
+
+        // System
+        CatalogApp("Thunar", "thunar", "thunar", "File manager", "System"),
+        CatalogApp("PCManFM", "pcmanfm", "pcmanfm", "File manager", "System"),
+        CatalogApp("xterm", "xterm", "xterm", "Terminal emulator", "System"),
+        CatalogApp("LXTerminal", "lxterminal", "lxterminal", "Terminal emulator", "System"),
+        CatalogApp("LXDE Task Manager", "lxtask", "lxtask", "Task manager", "System"),
+        CatalogApp("GParted", "gparted", "gparted", "Partition editor", "System"),
+        CatalogApp("Synaptic", "synaptic", "synaptic", "Package manager GUI", "System"),
+
+        // Games
+        CatalogApp("Solitaire (AisleRiot)", "aisleriot", "sol", "Card games collection", "Games"),
+        CatalogApp("GNOME Mines", "gnome-mines", "gnome-mines", "Minesweeper", "Games"),
+        CatalogApp("GNOME Sudoku", "gnome-sudoku", "gnome-sudoku", "Sudoku puzzle", "Games"),
+        CatalogApp("SuperTuxKart", "supertuxkart", "supertuxkart", "Racing game", "Games"),
+
+        // Communication
+        CatalogApp("HexChat", "hexchat", "hexchat", "IRC client", "Communication"),
+        CatalogApp("Pidgin", "pidgin", "pidgin", "Multi-protocol messenger", "Communication"),
+        CatalogApp("Thunderbird", "thunderbird", "thunderbird", "Email client", "Communication")
+    )
+
+    fun search(query: String): List<CatalogApp> {
+        if (query.isBlank()) return apps
+        val q = query.lowercase()
+        return apps.filter {
+            it.name.lowercase().contains(q) ||
+            it.packageName.lowercase().contains(q) ||
+            it.description.lowercase().contains(q) ||
+            it.category.lowercase().contains(q)
+        }
+    }
+
+    fun getByCategory(category: String): List<CatalogApp> {
+        return apps.filter { it.category == category }
+    }
+}

--- a/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/StoreScreen.kt
+++ b/src/app/src/main/java/ch/pianonic/pauxb/ui/screens/StoreScreen.kt
@@ -1,0 +1,323 @@
+package ch.pianonic.pauxb.ui.screens
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import ch.pianonic.pauxb.data.AppCatalog
+import ch.pianonic.pauxb.data.CatalogApp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StoreScreen(
+    installedAppIds: Set<String>,
+    installingAppIds: Set<String>,
+    onInstallApp: (name: String, packageName: String, command: String) -> Unit,
+    onSearchDebian: (query: String) -> Unit,
+    debianSearchResults: List<DebianSearchResult>,
+    isSearching: Boolean,
+    modifier: Modifier = Modifier
+) {
+    var searchQuery by remember { mutableStateOf("") }
+    var selectedCategory by remember { mutableStateOf<String?>(null) }
+    var showDebianSearch by remember { mutableStateOf(false) }
+
+    val catalogResults = remember(searchQuery, selectedCategory) {
+        when {
+            searchQuery.isNotBlank() -> AppCatalog.search(searchQuery)
+            selectedCategory != null -> AppCatalog.getByCategory(selectedCategory!!)
+            else -> AppCatalog.apps
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("App Store") })
+        },
+        modifier = modifier
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // Search bar
+            item {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = {
+                        searchQuery = it
+                        selectedCategory = null
+                        showDebianSearch = false
+                    },
+                    placeholder = { Text("Search apps...") },
+                    leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            // Category chips
+            item {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(AppCatalog.categories) { category ->
+                        FilterChip(
+                            selected = selectedCategory == category,
+                            onClick = {
+                                selectedCategory = if (selectedCategory == category) null else category
+                                searchQuery = ""
+                                showDebianSearch = false
+                            },
+                            label = { Text(category) }
+                        )
+                    }
+                }
+            }
+
+            // Catalog results
+            items(catalogResults) { app ->
+                val appId = app.name.lowercase().replace(" ", "_")
+                val isInstalled = appId in installedAppIds
+                val isInstalling = appId in installingAppIds
+
+                CatalogAppCard(
+                    app = app,
+                    isInstalled = isInstalled,
+                    isInstalling = isInstalling,
+                    onInstall = { onInstallApp(app.name, app.packageName, app.command) }
+                )
+            }
+
+            // No catalog results + search query = offer Debian search
+            if (catalogResults.isEmpty() && searchQuery.isNotBlank()) {
+                item {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Text(
+                                text = "Not in catalog",
+                                style = MaterialTheme.typography.titleSmall
+                            )
+                            Text(
+                                text = "Search Debian repositories for \"$searchQuery\"?",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Button(
+                                onClick = {
+                                    showDebianSearch = true
+                                    onSearchDebian(searchQuery)
+                                }
+                            ) {
+                                Text("Search Debian Packages")
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Debian search results
+            if (showDebianSearch) {
+                if (isSearching) {
+                    item {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            horizontalArrangement = Arrangement.Center,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Text("Searching Debian packages...")
+                        }
+                    }
+                }
+
+                if (debianSearchResults.isNotEmpty()) {
+                    item {
+                        Text(
+                            text = "Debian Packages",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.secondary,
+                            modifier = Modifier.padding(top = 8.dp)
+                        )
+                    }
+                    items(debianSearchResults) { result ->
+                        val appId = result.name.lowercase().replace(" ", "_")
+                        val isInstalled = appId in installedAppIds
+                        val isInstalling = appId in installingAppIds
+
+                        DebianResultCard(
+                            result = result,
+                            isInstalled = isInstalled,
+                            isInstalling = isInstalling,
+                            onInstall = { onInstallApp(result.name, result.packageName, result.packageName) }
+                        )
+                    }
+                }
+
+                if (!isSearching && debianSearchResults.isEmpty() && showDebianSearch) {
+                    item {
+                        Text(
+                            text = "No packages found for \"$searchQuery\"",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(16.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+data class DebianSearchResult(
+    val name: String,
+    val packageName: String,
+    val description: String
+)
+
+@Composable
+private fun CatalogAppCard(
+    app: CatalogApp,
+    isInstalled: Boolean,
+    isInstalling: Boolean,
+    onInstall: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateContentSize()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = app.name,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = app.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = app.packageName,
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            when {
+                isInstalling -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp
+                    )
+                }
+                isInstalled -> {
+                    Text(
+                        text = "Installed",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+                else -> {
+                    Button(onClick = onInstall) {
+                        Text("Install")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DebianResultCard(
+    result: DebianSearchResult,
+    isInstalled: Boolean,
+    isInstalling: Boolean,
+    onInstall: () -> Unit
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .animateContentSize()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = result.name,
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = result.description,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2
+                )
+                Text(
+                    text = result.packageName,
+                    fontFamily = FontFamily.Monospace,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.outline
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            when {
+                isInstalling -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp
+                    )
+                }
+                isInstalled -> {
+                    Text(
+                        text = "Installed",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+                else -> {
+                    Button(onClick = onInstall) {
+                        Text("Install")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New **Store** tab in the bottom navigation with a curated catalog of 35+ popular Linux GUI apps
- 8 categories: Browsers, Office, Graphics, Media, Development, System, Games, Communication
- Search bar filters the catalog instantly
- One-tap **Install** button auto-fills name, package, and command — no manual entry needed
- Shows "Installing..." spinner during install, "Installed" badge when done
- If an app isn't in the catalog, offers to search Debian repositories via `apt-cache search`
- Debian search results also have one-tap install

## New Files
- `AppCatalog.kt` — curated app database with search/filter
- `StoreScreen.kt` — store UI with catalog cards, category chips, and Debian search

## Changed Files
- `MainActivity.kt` — added Store tab, Debian search state, and store install handler
- `TermuxBridge.kt` — added `searchDebianPackages()`, `getSearchStatus()`, `getSearchResults()`

## Test plan
- [ ] Open Store tab — verify catalog loads with categories
- [ ] Tap a category chip — verify filtering works
- [ ] Type in search bar — verify instant filtering
- [ ] Tap Install on a catalog app — verify spinner shows, then "Installed" appears
- [ ] Search for something not in catalog — verify "Search Debian Packages" button appears
- [ ] Tap "Search Debian Packages" — verify results from apt-cache appear
- [ ] Install from Debian results — verify it works

Fixes #38